### PR TITLE
feature/content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Crawler - Proof of Concept
 
-* Current version: *1.0.0*
+* Current version: *1.0.1*
 
 Crawler POC using **Scala** and **Akka Streams**.
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file(".")).
     inThisBuild(List(
       organization := "com.rhdzmota",
       scalaVersion := "2.12.6",
-      version      := "1.0.0"
+      version      := "1.0.1"
     )),
     name := "crawler-poc",
     libraryDependencies ++= {

--- a/src/main/scala/com/rhdzmota/crawler/App.scala
+++ b/src/main/scala/com/rhdzmota/crawler/App.scala
@@ -4,7 +4,7 @@ import akka.NotUsed
 import akka.stream.ClosedShape
 import akka.stream.alpakka.googlecloud.pubsub.ReceivedMessage
 import akka.stream.scaladsl.{Broadcast, GraphDSL, RunnableGraph}
-import com.rhdzmota.crawler.model.Url
+import com.rhdzmota.crawler.model.{CustomResponse, Url}
 import com.rhdzmota.crawler.service.database.impl.Cassandra
 import com.rhdzmota.crawler.service.pubsub.impl.GCPubSub
 import com.rhdzmota.crawler.service.storage.impl.GCStorage
@@ -17,7 +17,7 @@ object App extends Context {
 
       // Broadcasting Variables
       val bcastReceivedMessages = builder.add(Broadcast[ReceivedMessage](outputPorts = 2))
-      val bcastDownload         = builder.add(Broadcast[(Url, Option[String])](outputPorts = 4))
+      val bcastDownload         = builder.add(Broadcast[CustomResponse](outputPorts  = 4))
 
       // Runnable Graph Definition
       GCPubSub.source ~>  bcastReceivedMessages ~> Crawler.validateAndDownload  ~>  bcastDownload ~> Crawler.extractUrls        ~> GCPubSub.sink

--- a/src/main/scala/com/rhdzmota/crawler/model/CustomResponse.scala
+++ b/src/main/scala/com/rhdzmota/crawler/model/CustomResponse.scala
@@ -1,0 +1,5 @@
+package com.rhdzmota.crawler.model
+
+import akka.http.scaladsl.model.MediaType
+
+case class CustomResponse(url: Url, content: Option[Array[Byte]], mediaType: Option[MediaType])


### PR DESCRIPTION
#  Description
#### What does this PR do? 
This PR allows the app to save the documents extracted from the Crawler in Google Storage **with file extension**. To achieve this, a custom case class used to represent get responses was implemented (instead of a tuple used previously).

#### Relevant changes
See the `model` package and the `GCStorage` object, 

# To the reviewer
#### Context 
Previously the application used a tuple (e.g. `(String, Option[String)`) to represent the response of a get request. Therefore, we didn't know the content types to upload the documents into Google Storage. 

#### Where to start
See the new `CustomResponse` case class in the `model` package and the usage in `ClientHttp` in the `util` package.

#### Tests instructions
There are no tests so far. 

# Self-Evaluation Keypoints
To the owner of this PR: answer 'yes' if the following key points are met. 
* Single responsibility principle: **yes**
* Code builds/run: **yes**
* Tests: **no**
* Self-documented: **yes**  
* Consistent code-style: **maybe**
* Subjective best-practices: **maybe**

# Requests and further questions 
None.